### PR TITLE
feat(controller-grpcburner):GrpcBurnerコントローラのReconcile実装

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -201,6 +201,14 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+	if err = (&controller.GrpcBurnerReconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("grpcburner-controller"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "GrpcBurner")
+		os.Exit(1)
+	}
 
 	if err := (&controller.ObservabilityConfigReconciler{
 		Client: mgr.GetClient(),

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,4 +1,18 @@
-# This patch adds the args to allow exposing the metrics endpoint using HTTPS
-- op: add
-  path: /spec/template/spec/containers/0/args/0
-  value: --metrics-bind-address=:8443
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+selector:
+  spec:
+    template:
+      spec:
+        containers:
+          - name: manager
+            args:
+              - --leader-elect
+              - --metrics-bind-address=:8080
+              - --metrics-secure=false
+            ports:
+              - containerPort: 8080
+                name: metrics

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -1,18 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    control-plane: controller-manager
-    app.kubernetes.io/name: cloudnative-observability-operator
-    app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system
+  labels:
+    control-plane: controller-manager
 spec:
-  ports:
-  - name: https
-    port: 8443
-    protocol: TCP
-    targetPort: 8443
   selector:
     control-plane: controller-manager
-    app.kubernetes.io/name: cloudnative-observability-operator
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics
+      protocol: TCP

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: ghcr.io/stsukada/cloudnative-observability-operator
+  newTag: 0.1.0

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,27 +1,16 @@
-# Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  labels:
-    control-plane: controller-manager
-    app.kubernetes.io/name: cloudnative-observability-operator
-    app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
-  endpoints:
-    - path: /metrics
-      port: https # Ensure this is the name of the port that exposes HTTPS metrics
-      scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        # TODO(user): The option insecureSkipVerify: true is not recommended for production since it disables
-        # certificate verification, exposing the system to potential man-in-the-middle attacks.
-        # For production environments, it is recommended to use cert-manager for automatic TLS certificate management.
-        # To apply this configuration, enable cert-manager and use the patch located at config/prometheus/servicemonitor_tls_patch.yaml,
-        # which securely references the certificate from the 'metrics-server-cert' secret.
-        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager
-      app.kubernetes.io/name: cloudnative-observability-operator
+  namespaceSelector:
+    matchNames: ["system"]
+  endpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http
+      interval: 30s

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,7 +8,9 @@ rules:
   - ""
   resources:
   - configmaps
+  - events
   - secrets
+  - serviceaccounts
   - services
   verbs:
   - create
@@ -35,6 +37,7 @@ rules:
 - apiGroups:
   - observability.shtsukada.dev
   resources:
+  - grpcburners
   - observabilityconfigs
   verbs:
   - create
@@ -47,12 +50,14 @@ rules:
 - apiGroups:
   - observability.shtsukada.dev
   resources:
+  - grpcburners/finalizers
   - observabilityconfigs/finalizers
   verbs:
   - update
 - apiGroups:
   - observability.shtsukada.dev
   resources:
+  - grpcburners/status
   - observabilityconfigs/status
   verbs:
   - get

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,10 @@ go 1.24.0
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
+	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.21.0
 )
 
@@ -82,13 +84,11 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.33.0 // indirect
 	k8s.io/apiextensions-apiserver v0.33.0 // indirect
 	k8s.io/apiserver v0.33.0 // indirect
 	k8s.io/component-base v0.33.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/controller/grpcburner_controller.go
+++ b/internal/controller/grpcburner_controller.go
@@ -1,0 +1,159 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	apiv1alpha1 "github.com/shtsukada/cloudnative-observability-operator/api/v1alpha1"
+)
+
+const finalizerName = "grpcburner.finalizers.observability.shtsukada.dev"
+
+// +kubebuilder:rbac:groups=observability.shtsukada.dev,resources=grpcburners,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=observability.shtsukada.dev,resources=grpcburners/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=observability.shtsukada.dev,resources=grpcburners/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=serviceaccounts;services;events,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+
+type GrpcBurnerReconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+}
+
+func (r *GrpcBurnerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var gb apiv1alpha1.GrpcBurner
+	if err := r.Get(ctx, req.NamespacedName, &gb); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !gb.ObjectMeta.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(&gb, finalizerName) {
+			controllerutil.RemoveFinalizer(&gb, finalizerName)
+			if err := r.Update(ctx, &gb); err != nil {
+				return ctrl.Result{}, err
+			}
+			r.Recorder.Event(&gb, corev1.EventTypeNormal, "Finalized", "Finalizer cleanup completed")
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(&gb, finalizerName) {
+		controllerutil.AddFinalizer(&gb, finalizerName)
+		if err := r.Update(ctx, &gb); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	r.setCondition(&gb, apiv1alpha1.ConditionProgressing, metav1.ConditionTrue, "Reconciling", "Reconciling desired state")
+	if err := r.Status().Update(ctx, &gb); err != nil {
+		logger.V(1).Info("status update (progressing) failed", "err", err)
+	}
+
+	sa := desiredServiceAccount(&gb)
+	svc := desiredService(&gb)
+	deploy := desiredDeployment(&gb)
+
+	if err := r.createOrUpdate(ctx, &gb, sa, func() error { return nil }); err != nil {
+		return r.fail(&gb, "ServiceAccountApplyFailed", err)
+	}
+	if err := r.createOrUpdate(ctx, &gb, svc, func() error { return nil }); err != nil {
+		return r.fail(&gb, "ServiceApplyFailed", err)
+	}
+	if err := r.createOrUpdate(ctx, &gb, deploy, func() error { return nil }); err != nil {
+		return r.fail(&gb, "DeploymentApplyFailed", err)
+	}
+
+	var d appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, &d); err == nil {
+		if d.Status.ReadyReplicas == ptr.Deref(deploy.Spec.Replicas, 1) {
+			gb.SetCondition(apiv1alpha1.ConditionReady, metav1.ConditionTrue, "AsExpected", "Deployment ready")
+			gb.SetCondition(apiv1alpha1.ConditionProgressing, metav1.ConditionFalse, "Stable", "Reconcile stable")
+			_ = r.Status().Update(ctx, &gb)
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *GrpcBurnerReconciler) createOrUpdate(ctx context.Context, owner *apiv1alpha1.GrpcBurner, obj client.Object, mutate func() error) error {
+	if err := controllerutil.SetControllerReference(owner, obj, r.Scheme); err != nil {
+		return err
+	}
+	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	current := obj.DeepCopyObject().(client.Object)
+
+	if err := r.Get(ctx, key, current); err != nil {
+		if apierrors.IsNotFound(err) {
+			if err := mutate(); err != nil {
+				return err
+			}
+			if err := r.Create(ctx, obj); err != nil {
+				return err
+			}
+			r.Recorder.Event(owner, corev1.EventTypeNormal, "Created", fmt.Sprintf("%T %q created", obj, key.Name))
+			return nil
+		}
+		return err
+	}
+	if err := mutate(); err != nil {
+		return err
+	}
+	obj.SetResourceVersion(current.GetResourceVersion())
+	if err := r.Update(ctx, obj); err != nil {
+		return err
+	}
+	r.Recorder.Event(owner, corev1.EventTypeNormal, "Updated", fmt.Sprintf("%T %q updated", obj, key.Name))
+	return nil
+}
+
+func (r *GrpcBurnerReconciler) setCondition(gb *apiv1alpha1.GrpcBurner, cond string, status metav1.ConditionStatus, reason, msg string) {
+	gb.SetCondition(cond, status, reason, msg)
+}
+
+func (r *GrpcBurnerReconciler) fail(gb *apiv1alpha1.GrpcBurner, reason string, err error) (ctrl.Result, error) {
+	r.Recorder.Event(gb, corev1.EventTypeWarning, reason, err.Error())
+	gb.SetCondition(apiv1alpha1.ConditionDegraded, metav1.ConditionTrue, reason, err.Error())
+	gb.SetCondition(apiv1alpha1.ConditionReady, metav1.ConditionFalse, reason, "Not ready")
+	_ = r.Status().Update(context.Background(), gb)
+	return ctrl.Result{}, err
+}
+
+func (r *GrpcBurnerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&apiv1alpha1.GrpcBurner{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ServiceAccount{}).
+		Complete(r)
+}
+
+func mergeMap(dst, src map[string]string) map[string]string {
+	if dst == nil && src == nil {
+		return nil
+	}
+	if dst == nil {
+		dst = map[string]string{}
+	}
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/internal/controller/grpcburner_resources.go
+++ b/internal/controller/grpcburner_resources.go
@@ -1,0 +1,146 @@
+package controller
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	apiv1alpha1 "github.com/shtsukada/cloudnative-observability-operator/api/v1alpha1"
+)
+
+func labels(gb *apiv1alpha1.GrpcBurner) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":       "grpcburner",
+		"app.kubernetes.io/instance":   gb.Name,
+		"app.kubernetes.io/managed-by": "cloudnative-observability-operator",
+	}
+}
+
+func desiredServiceAccount(gb *apiv1alpha1.GrpcBurner) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-sa", gb.Name),
+			Namespace: gb.Namespace,
+			Labels:    labels(gb),
+		},
+	}
+}
+
+func desiredService(gb *apiv1alpha1.GrpcBurner) *corev1.Service {
+	lbl := labels(gb)
+
+	ports := func() []corev1.ServicePort {
+		if len(gb.Spec.Ports) == 0 {
+			return []corev1.ServicePort{{
+				Name:       "grpc",
+				Port:       50051,
+				Protocol:   corev1.ProtocolTCP,
+				TargetPort: intstr.FromInt(50051),
+			}}
+		}
+		out := make([]corev1.ServicePort, 0, len(gb.Spec.Ports))
+		for _, p := range gb.Spec.Ports {
+			svcPort := p.ContainerPort
+			if p.ServicePort != nil {
+				svcPort = *p.ServicePort
+			}
+			out = append(out, corev1.ServicePort{
+				Name:       p.Name,
+				Port:       svcPort,
+				Protocol:   p.Protocol,
+				TargetPort: intstr.FromInt(int(p.ContainerPort)),
+			})
+		}
+		return out
+	}()
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-svc", gb.Name),
+			Namespace: gb.Namespace,
+			Labels:    lbl,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: lbl,
+			Ports:    ports,
+		},
+	}
+}
+
+func desiredDeployment(gb *apiv1alpha1.GrpcBurner) *appsv1.Deployment {
+	lbl := labels(gb)
+
+	replicas := int32(1)
+	if gb.Spec.Replicas != nil {
+		replicas = *gb.Spec.Replicas
+	}
+
+	image := gb.Spec.Image
+
+	containerPorts := func() []corev1.ContainerPort {
+		if len(gb.Spec.Ports) == 0 {
+			return []corev1.ContainerPort{{Name: "grpc", ContainerPort: 50051}}
+		}
+		out := make([]corev1.ContainerPort, 0, len(gb.Spec.Ports))
+		for _, p := range gb.Spec.Ports {
+			out = append(out, corev1.ContainerPort{
+				Name:          p.Name,
+				ContainerPort: p.ContainerPort,
+				Protocol:      p.Protocol,
+			})
+		}
+		return out
+	}()
+
+	spec := appsv1.DeploymentSpec{
+		Replicas: ptr.To(replicas),
+		Selector: &metav1.LabelSelector{MatchLabels: lbl},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: lbl,
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: fmt.Sprintf("%s-sa", gb.Name),
+				Containers: []corev1.Container{
+					{
+						Name:      "server",
+						Image:     image,
+						Env:       gb.Spec.Env,
+						Resources: gb.Spec.Resources,
+						Ports:     containerPorts,
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(50051)},
+							},
+						},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(50051)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	switch gb.Spec.UpdateStrategy {
+	case apiv1alpha1.UpdateStrategyRecreate:
+		spec.Strategy = appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}
+	default:
+		spec.Strategy = appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType}
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-deploy", gb.Name),
+			Namespace: gb.Namespace,
+			Labels:    lbl,
+		},
+		Spec: spec,
+	}
+}


### PR DESCRIPTION
## 概要
- GrpcBurner CRに対するReconcileを実装しました。
- CR適用時にDeployment/Service/ServiceAccountを生成、更新、削除できるようになっています。
- Status.ConditionsのユーティリティをAPI側に追加し、Reconcile状況をイベント、Conditionに反映します。
- cmd/main.goにReconciler登録とEventRecorderを追加しました。
- メトリクス公開をHTTP/8080で有効化し、Service/ServiceMonitorを通じてPrometheusからスクレイプ可能にしました。
- RBACにeventsを追加し、Reconcile中のイベント出力を許可しました。

## 変更点
- internal/controller/grpcburner_controller.go を新規追加（Reconciler 本体）
- internal/controller/grpcburner_resources.go を新規追加（SA/Service/Deployment の desired 定義）
- api/v1alpha1/grpcburner_types.go に Conditions 操作用メソッドを追加
- cmd/main.go に GrpcBurnerReconciler の登録＋Recorder 追加
- config/default/manager_metrics_patch.yaml を修正し、HTTP/8080 でメトリクスを公開
- config/default/metrics_service.yaml / config/prometheus/monitor.yaml を修正し、Prometheus からのスクレイプに対応
- config/rbac/role.yaml を更新し、events へのアクセス権を付与
- go.mod を更新（依存パッケージ整理）