### PR TITLE
feat(conditions-events-shared):共通conditions/Eventsへルパ導入とコントローラ統合対応

### DIFF
--- a/api/v1alpha1/observabilityconfig_types.go
+++ b/api/v1alpha1/observabilityconfig_types.go
@@ -55,6 +55,9 @@ type ObservabilityConfigStatus struct {
 
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// +optional
+	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/observability.shtsukada.dev_observabilityconfigs.yaml
+++ b/config/crd/bases/observability.shtsukada.dev_observabilityconfigs.yaml
@@ -155,6 +155,9 @@ spec:
                 - Error
                 - Reconciling
                 type: string
+              readyReplicas:
+                format: int32
+                type: integer
               reason:
                 description: Reason for last transition
                 maxLength: 1024

--- a/internal/shared/conditions/classify.go
+++ b/internal/shared/conditions/classify.go
@@ -1,0 +1,21 @@
+package conditions
+
+import apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+func ClassifyApplyError(err error) string {
+	if err == nil {
+		return ReasonApplySucceeded
+	}
+	switch {
+	case apierrors.IsForbidden(err):
+		return ReasonErrForbidden
+	case apierrors.IsInvalid(err):
+		return ReasonErrInvalid
+	case apierrors.IsNotFound(err):
+		return ReasonErrNotFound
+	case apierrors.IsConflict(err):
+		return ReasonErrConflict
+	default:
+		return ReasonErrUnknown
+	}
+}

--- a/internal/shared/conditions/classify_test.go
+++ b/internal/shared/conditions/classify_test.go
@@ -1,0 +1,26 @@
+package conditions_test
+
+import (
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	. "github.com/shtsukada/cloudnative-observability-operator/internal/shared/conditions"
+)
+
+func TestClassifyApplyError(t *testing.T) {
+	if got := ClassifyApplyError(nil); got != ReasonApplySucceeded {
+		t.Fatalf("nil => %s", got)
+	}
+	if got := ClassifyApplyError(apierrors.NewForbidden(schema.GroupResource{Group: "", Resource: "deployments"}, "d", errors.New("x"))); got != ReasonErrForbidden {
+		t.Fatalf("forbidden => %s", got)
+	}
+	if got := ClassifyApplyError(apierrors.NewInvalid(schema.GroupKind{Group: "", Kind: "Deployment"}, "d", nil)); got != ReasonErrInvalid {
+		t.Fatalf("invalid => %s", got)
+	}
+	if got := ClassifyApplyError(errors.New("random")); got != ReasonErrUnknown {
+		t.Fatalf("unknown => %s", got)
+	}
+}

--- a/internal/shared/conditions/constants.go
+++ b/internal/shared/conditions/constants.go
@@ -1,0 +1,34 @@
+package conditions
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+const (
+	ConditionReady       = "Ready"
+	ConditionProgressing = "Progressing"
+	ConditionDegraded    = "Degraded"
+)
+
+const (
+	ReasonReconciling           = "Reconciling"
+	ReasonApplySucceeded        = "ApplySucceeded"
+	ReasonApplyFailed           = "ApplyFailed"
+	ReasonWaitingForDeployment  = "WaitingForDeployment"
+	ReasonDeploymentAvailable   = "DeploymentAvailable"
+	ReasonDeploymentUnavailable = "DeploymentUnavailable"
+	ReasonImagePullBackOff      = "ImagePullBackOff"
+	ReasonErrForbidden          = "Forbidden"
+	ReasonErrInvalid            = "Invalid"
+	ReasonErrNotFound           = "NotFound"
+	ReasonErrConflict           = "Conflict"
+	ReasonErrUnknown            = "Unknown"
+)
+
+const (
+	EventTypeNormal  = "Normal"
+	EventTypeWarning = "Warning"
+)
+
+var (
+	CondTrue  = metav1.ConditionTrue
+	CondFalse = metav1.ConditionFalse
+)

--- a/internal/shared/conditions/helpers.go
+++ b/internal/shared/conditions/helpers.go
@@ -1,0 +1,52 @@
+package conditions
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewCondition(condType string, status metav1.ConditionStatus, reason, message string) metav1.Condition {
+	now := metav1.NewTime(time.Now())
+	return metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: 0,
+		LastTransitionTime: now,
+	}
+}
+
+func Upsert(conds *[]metav1.Condition, c metav1.Condition) {
+	list := *conds
+	for i := range list {
+		if list[i].Type == c.Type {
+			if list[i].Status != c.Status {
+				c.LastTransitionTime = metav1.Now()
+			} else {
+				c.LastTransitionTime = list[i].LastTransitionTime
+			}
+			list[i] = c
+			*conds = list
+			return
+		}
+	}
+	*conds = append(*conds, c)
+}
+
+func ReadyTrue(msg string) metav1.Condition {
+	return NewCondition(ConditionReady, CondTrue, ReasonDeploymentAvailable, msg)
+}
+func ReadyFalseProgressing(msg string) metav1.Condition {
+	return NewCondition(ConditionReady, CondFalse, ReasonWaitingForDeployment, msg)
+}
+func ReadyFalseDegraded(reason, msg string) metav1.Condition {
+	return NewCondition(ConditionReady, CondFalse, reason, msg)
+}
+func Progressing(msg string) metav1.Condition {
+	return NewCondition(ConditionProgressing, CondTrue, ReasonReconciling, msg)
+}
+func Degraded(reason, msg string) metav1.Condition {
+	return NewCondition(ConditionDegraded, CondTrue, reason, msg)
+}

--- a/internal/shared/conditions/recorder.go
+++ b/internal/shared/conditions/recorder.go
@@ -1,0 +1,18 @@
+package conditions
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+func Emit(rec record.EventRecorder, obj runtime.Object, eventType, reason, msg string, args ...any) {
+	if rec == nil || obj == nil {
+		return
+	}
+	if len(args) > 0 {
+		msg = fmt.Sprintf(msg, args...)
+	}
+	rec.Event(obj, eventType, reason, msg)
+}

--- a/internal/shared/conditions/recorder_test.go
+++ b/internal/shared/conditions/recorder_test.go
@@ -1,0 +1,29 @@
+package conditions_test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+
+	. "github.com/shtsukada/cloudnative-observability-operator/internal/shared/conditions"
+)
+
+func TestEmit(t *testing.T) {
+	rec := record.NewFakeRecorder(10)
+	pod := &corev1.Pod{}
+
+	var obj runtime.Object = pod
+
+	Emit(rec, obj, EventTypeWarning, ReasonApplyFailed, "oops %d", 42)
+
+	select {
+	case e := <-rec.Events:
+		if len(e) == 0 {
+			t.Fatal("empty event")
+		}
+	default:
+		t.Fatal("no event emitted")
+	}
+}


### PR DESCRIPTION
## 概要
- GrpcBurner / ObservabilityConfig両コントローラでバラバラに実装していたCondition更新、Event発酵処理を共通化しました。これにより、正常/異常の遷移が統一され、kubuctl describeや関市での可観測性が向上します。

## 変更点
- 共有へルパ新設：internal/shared/conditions/
  - constants.go: ConditionType, Reason の定数
  - helpers.go: Ready/Progressing/Degraded の糖衣関数
  - classify.go: K8sエラー → Forbidden/Invalid/Conflict 等へ分類
  - recorder.go: Event発行ユーティリティ

- コントローラ修正
  - GrpcBurnerReconciler, ObservabilityConfigReconciler に EventRecorder フィールド追加
  - Reconcile 内で共通ヘルパを利用して Condition/Events を更新
  - apply失敗時に Warning Event を発行、成功時に Normal Event を発行
  - ObservedGeneration を毎回同期、GrpcBurner では ReadyReplicas を Status に反映

- テスト修正
  - observabilityconfig_controller_test.go を共有Reason対応に変更
  - FakeRecorder を導入し Event 発行をテストで吸収

- CRD修正
  - ObservabilityConfig CRD/Types に status.readyReplicas を追加