### PR TITLE
feat(helm-chart-with-crds):Helmチャート新設()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ Dockerfile.cross
 # Helm / Kubernetes
 # ----------------------------------------
 *.tgz
-charts/
 tmpcharts/
 Chart.lock
 # kubeconfig は通常グローバル .gitignore で管理

--- a/charts/cloudnative-observability-operator/.helmignore
+++ b/charts/cloudnative-observability-operator/.helmignore
@@ -1,0 +1,7 @@
+.git/
+.github/
+.DS_Store
+*.swp
+*.swo
+*.orig
+*.bak

--- a/charts/cloudnative-observability-operator/Chart.yaml
+++ b/charts/cloudnative-observability-operator/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: cloudnative-observability-operator
+description: Kubernetes Operator (gRPC app mgmt). CRDs bundled.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.26.0-0"
+home: https://github.com/shtsukada/cloudnative-observability-operator
+sources:
+  - https://github.com/shtsukada/cloudnative-observability-operator
+maintainers:
+  - name: shtsukada
+annotations:
+  artifacthub.io/prerelease: "true"

--- a/charts/cloudnative-observability-operator/crds/observability.shtsukada.dev_grpcburners.yaml
+++ b/charts/cloudnative-observability-operator/crds/observability.shtsukada.dev_grpcburners.yaml
@@ -1,0 +1,368 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: grpcburners.observability.shtsukada.dev
+spec:
+  group: observability.shtsukada.dev
+  names:
+    kind: GrpcBurner
+    listKind: GrpcBurnerList
+    plural: grpcburners
+    shortNames:
+    - gb
+    singular: grpcburner
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Summary phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Ready replicas
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              env:
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              image:
+                minLength: 1
+                type: string
+              otlpEndpoint:
+                properties:
+                  endpoint:
+                    description: e.g. "otel-collector.monitoring.svc:4317"
+                    minLength: 1
+                    type: string
+                  headers:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  insecure:
+                    default: false
+                    type: boolean
+                  timeout:
+                    type: string
+                required:
+                - endpoint
+                type: object
+              ports:
+                items:
+                  properties:
+                    containerPort:
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    name:
+                      type: string
+                    protocol:
+                      default: TCP
+                      description: Protocol defines network protocols supported for
+                        things like container ports.
+                      enum:
+                      - TCP
+                      - UDP
+                      - SCTP
+                      type: string
+                    servicePort:
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  required:
+                  - containerPort
+                  type: object
+                minItems: 1
+                type: array
+              replicas:
+                default: 1
+                format: int32
+                minimum: 0
+                type: integer
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              updateStrategy:
+                default: RollingUpdate
+                enum:
+                - RollingUpdate
+                - Recreate
+                type: string
+            required:
+            - image
+            - ports
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                type: string
+              readyReplicas:
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/cloudnative-observability-operator/crds/observability.shtsukada.dev_observabilityconfigs.yaml
+++ b/charts/cloudnative-observability-operator/crds/observability.shtsukada.dev_observabilityconfigs.yaml
@@ -1,0 +1,172 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: observabilityconfigs.observability.shtsukada.dev
+spec:
+  group: observability.shtsukada.dev
+  names:
+    categories:
+    - all
+    kind: ObservabilityConfig
+    listKind: ObservabilityConfigList
+    plural: observabilityconfigs
+    shortNames:
+    - obscfg
+    singular: observabilityconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .spec.samplingPercent
+      name: Sampling
+      type: integer
+    - jsonPath: .spec.metricsEnabled
+      name: Metrics
+      type: boolean
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ObservabilityConfig is the Schema for the observabilityconfigs
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ObservabilityConfigSpec defines the desired state of ObservabilityConfig
+            properties:
+              endpoint:
+                description: 'Example field: endpoint URL of OTLP exporter'
+                maxLength: 2048
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: endpoint must be http(s) URL or host:port
+                  rule: (self.matches('^https?://.+')) || (self.matches('^[A-Za-z0-9_.-]+:[0-9]{1,5}$'))
+              metricsEnabled:
+                default: true
+                description: Enable metrics pipeline
+                type: boolean
+              samplingPercent:
+                default: 10
+                description: 'Example: sampling ratio percent (0-100)'
+                format: int32
+                maximum: 100
+                minimum: 0
+                type: integer
+            required:
+            - endpoint
+            type: object
+          status:
+            description: ObservabilityConfigStatus defines the observed state of ObservabilityConfig.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                default: Reconciling
+                enum:
+                - Ready
+                - Error
+                - Reconciling
+                type: string
+              readyReplicas:
+                format: int32
+                type: integer
+              reason:
+                description: Reason for last transition
+                maxLength: 1024
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/cloudnative-observability-operator/templates/_helpers.tpl
+++ b/charts/cloudnative-observability-operator/templates/_helpers.tpl
@@ -1,0 +1,25 @@
+{{- define "cno.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "cno.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end }}
+
+{{- define "cno.labels" -}}
+app.kubernetes.io/name: {{ include "cno.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end }}
+
+{{- define "cno.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cno.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/cloudnative-observability-operator/templates/clusterrole.yaml
+++ b/charts/cloudnative-observability-operator/templates/clusterrole.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{include "cno.fullname" . }}
+  labels: {{- include "cno.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["observability.shtsukada.dev"]
+    resources:
+      - grpcburners
+      - grpcburners/status
+      - grpcburners/finalizers
+      - observabilityconfigs
+      - observabilityconfigs/status
+      - observabilityconfigs/finalizers
+    verbs: ["get","list","watch","create","update","patch","delete"]
+
+  - apiGroups: ["apps"]
+    resources: ["deployments","replicasets"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["pods","services","endpoints","events","configmaps","secrets"]
+    verbs: ["*"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["*"]
+{{- end }}

--- a/charts/cloudnative-observability-operator/templates/clusterrolebinding.yaml
+++ b/charts/cloudnative-observability-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cno.fullname" . }}
+  labels: {{- include "cno.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cno.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ default (include "cno.fullname" .) .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/cloudnative-observability-operator/templates/configmap-operator.yaml
+++ b/charts/cloudnative-observability-operator/templates/configmap-operator.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cno.fullname" . }}-config
+  labels: {{- include "cno.labels" . | nindent 4 }}
+data:
+  MANAGEDAPP_IMAGE: {{ printf "%s" .Values.managedApp.image | quote }}
+  MANAGEDAPP_TAG: {{ printf "%s" .Values.managedApp.tag | quote }}
+  MANAGEDAPP_REPLICAS: {{ printf "%v" .Values.managedApp.replicas | quote }}
+  MANAGEDAPP_OTLP_ENDPOINT: {{ printf "%s" .Values.managedApp.otlpEndpoint | quote }}
+  MANAGEDAPP_ENV_JSON: {{ toJson .Values.managedApp.env | quote }}
+  MANAGEDAPP_PORTS_JSON: {{ toJson .Values.managedApp.ports | quote }}

--- a/charts/cloudnative-observability-operator/templates/deployment.yaml
+++ b/charts/cloudnative-observability-operator/templates/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cno.fullname" . }}
+  labels: {{- include "cno.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "cno.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cno.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ default (include "cno.fullname" .) .Values.serviceAccount.name }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: manager
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--leader-elect={{ .Values.leaderElection.enabled }}"
+            - "--metrics-bind-address=:8080"
+            - "--health-probe-bind-address=:8081"
+            - "--zap-encoder=json"
+            - "--zap-log-level={{ (index (first .Values.operator.env) "value") | default "info" }}"
+          envFrom:
+            - configMapRef:
+                name: {{ include "cno.fullname" . }}-config
+          env:
+            {{- toYaml .Values.operator.env | nindent 12 }}
+          ports:
+            - { name: metrics, containerPort: 8080 }
+            - { name: healthz, containerPort: 8081 }
+          readinessProbe:
+            httpGet: { path: /readyz, port: 8081 }
+            initialDelaySeconds: 5
+          livenessProbe:
+            httpGet: { path: /healthz, port: 8081 }
+            initialDelaySeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/cloudnative-observability-operator/templates/service.yaml
+++ b/charts/cloudnative-observability-operator/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cno.fullname" . }}
+  labels: {{- include "cno.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "cno.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http-metrics
+      port: {{ .Values.service.port }}
+      targetPort: metrics

--- a/charts/cloudnative-observability-operator/templates/serviceaccount.yaml
+++ b/charts/cloudnative-observability-operator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default (include "cno.fullname" .) .Values.serviceAccount.name }}
+  labels:
+    {{- include "cno.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cloudnative-observability-operator/templates/servicemonitor.yaml
+++ b/charts/cloudnative-observability-operator/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cno.fullname" . }}
+  labels:
+    {{- include "cno.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "cno.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http-metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/cloudnative-observability-operator/values.yaml
+++ b/charts/cloudnative-observability-operator/values.yaml
@@ -1,0 +1,63 @@
+image:
+  repository: ghcr.io/shtsukada/cloudnative-observability-operator
+  tag: "v0.1.0"
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+resources:
+  requests: { cpu: 50m,memory: 128Mi }
+  limits: { cpu: 300m, memory: 512Mi }
+
+operator:
+  env:
+    - name: ZAP_LOG_LEVEL
+      value: "info"
+
+managedApp:
+  image: ghcr.io/shtsukada/grpc-burner
+  tag: "v0.1.0"
+  replicas: 1
+  otlpEndpoint: "http://otel-collector.monitoring:4317"
+  env:
+    - name: MODE
+      value: "cpu"
+    - name: QPS
+      value: "10"
+  ports:
+    - name: grpc
+      containerPort: 50051
+
+service:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels: {}
+
+rbac:
+  create: true
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+installCRDs: true
+
+leaderElection:
+  enabled: true
+
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile: { type: RuntimeDefault }
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]


### PR DESCRIPTION
## 概要
cloudnative-observability-operator を Helm チャートとして配布できるようにしました。
- チャート構成: charts/cloudnative-observability-operator/
- CRDs を crds/ に同梱（GrpcBurner / ObservabilityConfig）
- RBAC（ClusterRole/Binding）, ServiceAccount, Deployment, Service, ServiceMonitor をテンプレート化
- managedApp.* の既定値を ConfigMap にフラット化し、Deployment へ envFrom 注入

## 変更点
- 追加: charts/cloudnative-observability-operator/{Chart.yaml,values.yaml,.helmignore,templates/*,crds/*}
- テンプレ設計:
  - `apiGroups: observability.shtsukada.dev` に合わせた RBAC
  - Pod/Container セキュリティ既定（runAsNonRoot, readOnlyRootFilesystem, drop ALL）
  - ServiceMonitor は values で有効化可（kube-prometheus-stack 前提）
  - CRDs は crds/ に配置（Helmの仕様に従い install 時のみ適用。別管理時は --skip-crds を使用）