### PR TITLE
feat(security-baseline): PSS(restricted)準拠・最小RBAC・NetworkPolicyの導入

### DIFF
--- a/charts/cloudnative-observability-operator/templates/clusterrole.yaml
+++ b/charts/cloudnative-observability-operator/templates/clusterrole.yaml
@@ -1,27 +1,71 @@
-{{- if .Values.rbac.create }}
+{{- if not .Values.rbac.namespaced }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{include "cno.fullname" . }}
-  labels: {{- include "cno.labels" . | nindent 4 }}
+  name: {{ include "cloudnative-observability-operator.fullname" . }}
 rules:
+  # 自CRD（参照） + status/finalizers 更新のみ
   - apiGroups: ["observability.shtsukada.dev"]
-    resources:
-      - grpcburners
-      - grpcburners/status
-      - grpcburners/finalizers
-      - observabilityconfigs
-      - observabilityconfigs/status
-      - observabilityconfigs/finalizers
+    resources: ["grpcburners","grpcburners/status","grpcburners/finalizers","observabilityconfigs","observabilityconfigs/status","observabilityconfigs/finalizers"]
+    verbs: ["get","list","watch"]
+  - apiGroups: ["observability.shtsukada.dev"]
+    resources: ["grpcburners/status","observabilityconfigs/status"]
+    verbs: ["update","patch"]
+  - apiGroups: ["observability.shtsukada.dev"]
+    resources: ["grpcburners/finalizers","observabilityconfigs/finalizers"]
+    verbs: ["update"]
+
+  # 管理対象（必要最小）
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get","list","watch","create","update","patch","delete"]
+  - apiGroups: [""]
+    resources: ["services","configmaps"]
     verbs: ["get","list","watch","create","update","patch","delete"]
 
-  - apiGroups: ["apps"]
-    resources: ["deployments","replicasets"]
-    verbs: ["*"]
+  # pods は参照のみ
   - apiGroups: [""]
-    resources: ["pods","services","endpoints","events","configmaps","secrets"]
-    verbs: ["*"]
+    resources: ["pods"]
+    verbs: ["get","list","watch"]
+
+  # events 記録
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","patch"]
+
+  # leader election
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["*"]
+    verbs: ["get","list","watch","create","update","patch"]
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cloudnative-observability-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["observability.shtsukada.dev"]
+    resources: ["grpcburners","grpcburners/status","grpcburners/finalizers","observabilityconfigs","observabilityconfigs/status","observabilityconfigs/finalizers"]
+    verbs: ["get","list","watch"]
+  - apiGroups: ["observability.shtsukada.dev"]
+    resources: ["grpcburners/status","observabilityconfigs/status"]
+    verbs: ["update","patch"]
+  - apiGroups: ["observability.shtsukada.dev"]
+    resources: ["grpcburners/finalizers","observabilityconfigs/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get","list","watch","create","update","patch","delete"]
+  - apiGroups: [""]
+    resources: ["services","configmaps"]
+    verbs: ["get","list","watch","create","update","patch","delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get","list","watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get","list","watch","create","update","patch"]
 {{- end }}

--- a/charts/cloudnative-observability-operator/templates/clusterrolebinding.yaml
+++ b/charts/cloudnative-observability-operator/templates/clusterrolebinding.yaml
@@ -1,15 +1,28 @@
-{{- if .Values.rbac.create }}
+{{- if not .Values.rbac.namespaced }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "cno.fullname" . }}
-  labels: {{- include "cno.labels" . | nindent 4 }}
+  name: {{ include "cloudnative-observability-operator.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "cno.fullname" . }}
+  name: {{ include "cloudnative-observability-operator.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ default (include "cno.fullname" .) .Values.serviceAccount.name }}
+    name: {{ include "cloudnative-observability-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cloudnative-observability-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cloudnative-observability-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cloudnative-observability-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/cloudnative-observability-operator/templates/deployment.yaml
+++ b/charts/cloudnative-observability-operator/templates/deployment.yaml
@@ -15,14 +15,21 @@ spec:
     spec:
       serviceAccountName: {{ default (include "cno.fullname" .) .Values.serviceAccount.name }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        runAsNonRoot: {{ .Values.security.podSecurityContext.runAsNonRoot }}
+        {{- if .Values.security.podSecurityContext.enabledFixedIDs }}
+        runAsUser: {{ .Values.security.podSecurityContext.runAsUser }}
+        runAsGroup: {{ .Values.security.podSecurityContext.runAsGroup }}
+        fsGroup: {{ .Values.security.podSecurityContext.fsGroup }}
+        {{- end }}
+        seccompProfile:
+          type: {{ .Values.security.podSecurityContext.seccompProfile.type }}
       containers:
         - name: manager
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "--leader-elect={{ .Values.leaderElection.enabled }}"
-            - "--metrics-bind-address=:8080"
+            - "--metrics-bind-address=:{{ .Values.networkPolicy.metricsPort }}"
             - "--health-probe-bind-address=:8081"
             - "--zap-encoder=json"
             - "--zap-log-level={{ (index (first .Values.operator.env) "value") | default "info" }}"
@@ -32,8 +39,10 @@ spec:
           env:
             {{- toYaml .Values.operator.env | nindent 12 }}
           ports:
-            - { name: metrics, containerPort: 8080 }
-            - { name: healthz, containerPort: 8081 }
+            - name: metrics
+              containerPort: {{ .Values.networkPolicy.metricsPort }}
+            - name: healthz
+              containerPort: 8081
           readinessProbe:
             httpGet: { path: /readyz, port: 8081 }
             initialDelaySeconds: 5
@@ -43,4 +52,16 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            readOnlyRootFilesystem: {{ .Values.security.containerSecurityContext.readOnlyRootFilesystem }}
+            allowPrivilegeEscalation: {{ .Values.security.containerSecurityContext.allowPrivilegeEscalation }}
+            capabilities:
+              drop:
+              {{- range .Values.security.containerSecurityContext.capabilities.drop }}
+                - {{ . }}
+              {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/charts/cloudnative-observability-operator/templates/networkpolicy.yaml
+++ b/charts/cloudnative-observability-operator/templates/networkpolicy.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "cloudnative-observability-operator.fullname" . }}-default-deny
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cloudnative-observability-operator.name" . }}
+  policyTypes: ["Ingress","Egress"]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "cloudnative-observability-operator.fullname" . }}-allow-metrics
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cloudnative-observability-operator.name" . }}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.prometheusNamespace | quote }}
+      ports:
+        - port: {{ .Values.networkPolicy.metricsPort }}
+          protocol: TCP
+---
+{{- if .Values.networkPolicy.otlp.inCluster.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "cloudnative-observability-operator.fullname" . }}-allow-otlp-egress-incluster
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cloudnative-observability-operator.name" . }}
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.otlp.inCluster.namespace | quote }}
+          podSelector:
+{{ toYaml .Values.networkPolicy.otlp.inCluster.podSelector | indent 12 }}
+      ports:
+        - port: {{ .Values.networkPolicy.otlp.inCluster.port }}
+          protocol: TCP
+  policyTypes: ["Egress"]
+{{- end }}
+---
+{{- if .Values.networkPolicy.otlp.external.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "cloudnative-observability-operator.fullname" . }}-allow-otlp-egress-external
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cloudnative-observability-operator.name" . }}
+  egress:
+    - to:
+      {{- range $cidr := .Values.networkPolicy.otlp.external.ipBlockCIDRs }}
+        - ipBlock:
+            cidr: {{ $cidr | quote }}
+      {{- end }}
+      ports:
+        - port: {{ .Values.networkPolicy.otlp.external.port }}
+          protocol: TCP
+  policyTypes: ["Egress"]
+{{- end }}
+{{- end }}

--- a/charts/cloudnative-observability-operator/values.yaml
+++ b/charts/cloudnative-observability-operator/values.yaml
@@ -6,7 +6,7 @@ image:
 replicaCount: 1
 
 resources:
-  requests: { cpu: 50m,memory: 128Mi }
+  requests: { cpu: 50m, memory: 128Mi }
   limits: { cpu: 300m, memory: 512Mi }
 
 operator:
@@ -41,6 +41,7 @@ serviceMonitor:
 
 rbac:
   create: true
+  namespaced: false
 
 serviceAccount:
   create: true
@@ -52,12 +53,34 @@ installCRDs: true
 leaderElection:
   enabled: true
 
-podSecurityContext:
-  runAsNonRoot: true
-  seccompProfile: { type: RuntimeDefault }
+security:
+  podSecurityContext:
+    runAsNonRoot: true
+    enabledFixedIDs: false
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
 
-securityContext:
-  allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: true
-  capabilities:
-    drop: ["ALL"]
+networkPolicy:
+  enabled: true
+  prometheusNamespace: "monitoring"
+  metricsPort: 8080
+  otlp:
+    inCluster:
+      enabled: true
+      namespace: "monitoring"
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: "otel-collector"
+      port: 4317
+    external:
+      enabled: false
+      ipBlockCIDRs: ["0.0.0.0/0"]
+      port: 4317


### PR DESCRIPTION
## 概要
cloudnative-observability-operatorのセキュリティ・ベースラインを導入しました。
Pod Security Standards のrestricted相当を既定化し、RBAC最小権限化、NetworkPolicyによる最小許可を適用しています。これによりオペレーターPodが危険な権限を使わず動作し、万一侵害されても被害を最小化します。

## 変更点
1) Pod Security（PSS “restricted” 準拠 + 実務強化）
- Pod(template.spec.securityContext)
  - runAsNonRoot:true
  - semcompProfile:RuntimeDefault
  - runAsUser/runAsGroup/fsGroupをvaluesで固定可能
- Container(containers[].securityContext)
  - readOnlyRootFilesystem:true
  - allowPrivilegeEscalation:false
  - capabilities.drop:["ALL"]
- /tmp用にemptyDirを追加
- metrics/healthzポートの定義をvaluesと整合(neworkPolicy.metricsPort)
2) RBAC 最小権限
- 自CRD(obserability.shtsukada.dev)
  - 参照：get/list/watch
  - 更新：status,finalizersのみupdate/patch
- 管理対象
  - deployments（apps）: get/list/watch/create/update/patch/delete
  - services, configmaps（core）: 同上
  - pods: get/list/watch のみ
  - events: create/patch
  - leases: get/list/watch/create/update/patch（リーダー選出）
- rbac.namespaced で ClusterRole/Binding ↔ Role/Binding を切替可能（単一NS運用向け）
3) NetworkPolicy（最小許可）
- default-deny（Ingress/Egress）
- allow-metrics（Ingress: Prometheus Namespace → Podの 8080/TCP）
- allow-healthz（Ingress: 8081/TCP を任意送信元から許可：kubelet プローブ通過用）
- allow-otlp（Egress: 4317/TCP。in-cluster の Collector または external CIDR）
4) values.yaml の追加/統一
- security.*（Pod/Container の securityContext 既定）
- rbac.namespaced（false=ClusterRole、true=Role）
- networkPolicy.*（enabled, prometheusNamespace, metricsPort, otlp.*）
- ServiceMonitor の追加ラベルは serviceMonitor.additionalLabels に統一
5) Service/ServiceMonitor の整合
- Service: ports[0].name: http-metrics / targetPort: metrics
- ServiceMonitor: endpoints[0].port: http-metrics
- Deployment（Pod）: containers[].ports[].name: metrics / containerPort: 8080