### PR TITLE
feat(ci-pr-guards):

### DIFF
--- a/.github/workflows/ci-pr-guards.yml
+++ b/.github/workflows/ci-pr-guards.yml
@@ -1,0 +1,50 @@
+name: CI PR Guards
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [ feature/ci-pr-guards ]
+
+jobs:
+  ci:
+    name: make ci-all
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+
+      - name: Cache envtest binaries
+        id: cache-envtest
+        uses: actions/cache@v4
+        with:
+          path: bin/k8s
+          key: envtest-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
+
+      - name: Make tools (golangci-lint, controller-gen, kustomize, etc.)
+        run: make tools
+
+      - name: Run CI suite
+        env:
+          GOOS: linux
+          GOARCH: amd64
+          CGO_ENABLED: 0
+        run: make ci-all

--- a/charts/cloudnative-observability-operator/templates/_helpers.tpl
+++ b/charts/cloudnative-observability-operator/templates/_helpers.tpl
@@ -1,25 +1,48 @@
-{{- define "cno.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end }}
+{{/*
+Common template helpers
+*/}}
 
-{{- define "cno.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{/* Chart name */}}
+{{- define "cloudnative-observability-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Fully qualified release name */}}
+{{- define "cloudnative-observability-operator.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name (include "cloudnative-observability-operator.name" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- end }}
+{{- end -}}
 
-{{- define "cno.labels" -}}
-app.kubernetes.io/name: {{ include "cno.name" . }}
+{{/* Chart label */}}
+{{- define "cloudnative-observability-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Standard labels */}}
+{{- define "cloudnative-observability-operator.labels" -}}
+helm.sh/chart: {{ include "cloudnative-observability-operator.chart" . }}
+app.kubernetes.io/name: {{ include "cloudnative-observability-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
 {{- end }}
+{{- end -}}
 
-{{- define "cno.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "cno.name" . }}
+{{/* Selector labels (must be immutable) */}}
+{{- define "cloudnative-observability-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cloudnative-observability-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
+{{- end -}}
+
+{{/* ServiceAccount name */}}
+{{- define "cloudnative-observability-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "cloudnative-observability-operator.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/cloudnative-observability-operator/templates/configmap-operator.yaml
+++ b/charts/cloudnative-observability-operator/templates/configmap-operator.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "cno.fullname" . }}-config
-  labels: {{- include "cno.labels" . | nindent 4 }}
+  name: {{ include "cloudnative-observability-operator.fullname" . }}-config
+  labels: {{- include "cloudnative-observability-operator.labels" . | nindent 4 }}
 data:
   MANAGEDAPP_IMAGE: {{ printf "%s" .Values.managedApp.image | quote }}
   MANAGEDAPP_TAG: {{ printf "%s" .Values.managedApp.tag | quote }}

--- a/charts/cloudnative-observability-operator/templates/deployment.yaml
+++ b/charts/cloudnative-observability-operator/templates/deployment.yaml
@@ -1,91 +1,94 @@
+{{- /*
+Deployment template (nil-safe)
+
+- 依存ヘルパーは _helpers.tpl の
+  cloudnative-observability-operator.{fullname,labels,selectorLabels,serviceAccountName}
+- .Values が未定義/型不一致でも lint で落ちないよう、hasKey/kindIs/ternary でガード
+*/ -}}
+
+{{- $vals := .Values -}}
+
+{{- /* replicaCount */ -}}
+{{- $replicas := (hasKey $vals "replicaCount") | ternary $vals.replicaCount 1 -}}
+
+{{- /* image */ -}}
+{{- $img := (and (hasKey $vals "image") (kindIs "map[string]interface {}" $vals.image)) | ternary $vals.image (dict) -}}
+{{- $repo := (hasKey $img "repository") | ternary $img.repository "ghcr.io/stsukada/cloudnative-observability-operator" -}}
+{{- $tag  := (hasKey $img "tag")        | ternary $img.tag        .Chart.AppVersion -}}
+{{- $pull := (hasKey $img "pullPolicy") | ternary $img.pullPolicy "IfNotPresent" -}}
+
+{{- /* operator (env/args/resources など) */ -}}
+{{- $op := (and (hasKey $vals "operator") (kindIs "map[string]interface {}" $vals.operator)) | ternary $vals.operator (dict) -}}
+{{- $env := (and (hasKey $op "env") (kindIs "[]interface {}" $op.env)) | ternary $op.env (list) -}}
+{{- $args := (and (hasKey $op "args") (kindIs "[]interface {}" $op.args)) | ternary $op.args (list) -}}
+{{- $res := (and (hasKey $op "resources") (kindIs "map[string]interface {}" $op.resources)) | ternary $op.resources (dict) -}}
+{{- $sec := (and (hasKey $op "securityContext") (kindIs "map[string]interface {}" $op.securityContext)) | ternary $op.securityContext (dict) -}}
+{{- $podsec := (and (hasKey $op "podSecurityContext") (kindIs "map[string]interface {}" $op.podSecurityContext)) | ternary $op.podSecurityContext (dict) -}}
+{{- $imagePullSecrets := (and (hasKey $vals "imagePullSecrets") (kindIs "[]interface {}" $vals.imagePullSecrets)) | ternary $vals.imagePullSecrets (list) -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cno.fullname" . }}
-  labels: {{- include "cno.labels" . | nindent 4 }}
+  name: {{ include "cloudnative-observability-operator.fullname" . }}
+  labels:
+    {{- include "cloudnative-observability-operator.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ $replicas }}
   selector:
     matchLabels:
-      {{- include "cno.selectorLabels" . | nindent 6 }}
+      {{- include "cloudnative-observability-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "cno.selectorLabels" . | nindent 8 }}
+        {{- include "cloudnative-observability-operator.selectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ default (include "cno.fullname" .) .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "cloudnative-observability-operator.serviceAccountName" . }}
+      {{- with $imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $podsec }}
       securityContext:
-        runAsNonRoot: {{ .Values.security.podSecurityContext.runAsNonRoot }}
-        {{- if .Values.security.podSecurityContext.enabledFixedIDs }}
-        runAsUser: {{ .Values.security.podSecurityContext.runAsUser }}
-        runAsGroup: {{ .Values.security.podSecurityContext.runAsGroup }}
-        fsGroup: {{ .Values.security.podSecurityContext.fsGroup }}
-        {{- end }}
-        seccompProfile:
-          type: {{ .Values.security.podSecurityContext.seccompProfile.type }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: manager
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-            - "--leader-elect={{ .Values.leaderElection.enabled }}"
-            - "--metrics-bind-address=:{{ .Values.networkPolicy.metricsPort }}"
-            - "--health-probe-bind-address=:8081"
-            - "--zap-encoder=json"
-            - "--zap-log-level={{ (index (first .Values.operator.env) "value") | default "info" }}"
-          envFrom:
-            - configMapRef:
-                name: {{ include "cno.fullname" . }}-config
-          env:
-            {{- toYaml .Values.operator.env | nindent 12 }}
-            - name: ZAP_LOG_JSON
-              value: "{{ ternary "true" "false" .Values.telemetry.logs.json }}"
-            - name: ZAP_LOG_LEVEL
-              value: "{{ .Values.telemetry.logs.level | default "info" }}"
-            - name: ZAP_SAMPLE
-              value: "{{ ternary "true" "false" .Values.telemetry.logs.sample }}"
-            - name: OTEL_TRACES_ENABLED
-              value: "{{ ternary "true" "false" .Values.telemetry.traces.enabled }}"
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: "{{ .Values.telemetry.traces.endpoint }}"
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: "grpc"
-            - name: OTEL_TRACES_SAMPLER
-              value: "{{ .Values.telemetry.traces.sampler }}"
-            - name: OTEL_TRACES_SAMPLER_ARG
-              value: "{{ .Values.telemetry.traces.samplerArg | toString }}"
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name={{ .Values.telemetry.traces.serviceName }},k8s.namespace=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME)"
-            - name: OTEL_SERVICE_NAME
-              value: "{{ .Values.telemetry.traces.serviceName }}"
-            - name: POD_NAME
-              valueFrom: { fieldRef: { fieldPath: metadata.name } }
-            - name: POD_NAMESPACE
-              valueFrom: { fieldRef: { fieldPath: metadata.namespace } }
+          image: {{ printf "%s:%s" $repo $tag | quote }}
+          imagePullPolicy: {{ $pull }}
           ports:
-            - name: metrics
-              containerPort: {{ .Values.networkPolicy.metricsPort }}
-            - name: healthz
+            # controller-runtime metrics (デフォルト https/8443)
+            - name: https
+              containerPort: 8443
+              protocol: TCP
+            # health probe (kubebuilder 既定 8081)
+            - name: health
               containerPort: 8081
-          readinessProbe:
-            httpGet: { path: /readyz, port: 8081 }
-            initialDelaySeconds: 5
-          livenessProbe:
-            httpGet: { path: /healthz, port: 8081 }
-            initialDelaySeconds: 10
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+              protocol: TCP
+          args:
+            {{- if $args }}
+            {{- toYaml $args | nindent 12 }}
+            {{- else }}
+            - --metrics-bind-address=:8443
+            - --health-probe-bind-address=:8081
+            {{- end }}
+          {{- with $env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $sec }}
           securityContext:
-            readOnlyRootFilesystem: {{ .Values.security.containerSecurityContext.readOnlyRootFilesystem }}
-            allowPrivilegeEscalation: {{ .Values.security.containerSecurityContext.allowPrivilegeEscalation }}
-            capabilities:
-              drop:
-              {{- range .Values.security.containerSecurityContext.capabilities.drop }}
-                - {{ . }}
-              {{- end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $res }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
-            - name: tmp
-              mountPath: /tmp
+            - name: operator-config
+              mountPath: /etc/operator
+              readOnly: true
       volumes:
-        - name: tmp
-          emptyDir: {}
+        - name: operator-config
+          configMap:
+            name: {{ include "cloudnative-observability-operator.fullname" . }}-config
+            optional: true

--- a/charts/cloudnative-observability-operator/templates/networkpolicy.yaml
+++ b/charts/cloudnative-observability-operator/templates/networkpolicy.yaml
@@ -1,75 +1,27 @@
-{{- if .Values.networkPolicy.enabled }}
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: {{ include "cloudnative-observability-operator.fullname" . }}-default-deny
-  namespace: {{ .Release.Namespace }}
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/name: {{ include "cloudnative-observability-operator.name" . }}
-  policyTypes: ["Ingress","Egress"]
----
+{{- /*
+Render NetworkPolicy only when:
+  - .Values.networkPolicy.enabled == true
+Guard for type mismatches (bool vs map) to avoid lint errors.
+*/ -}}
+{{- $vals := .Values -}}
+{{- $np := (and (hasKey $vals "networkPolicy") (kindIs "map[string]interface {}" $vals.networkPolicy)) | ternary $vals.networkPolicy (dict) -}}
+{{- $enabled := (hasKey $np "enabled") | ternary $np.enabled false -}}
+{{- $metricsPort := (hasKey $np "metricsPort") | ternary $np.metricsPort 8443 -}}
+
+{{- if $enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "cloudnative-observability-operator.fullname" . }}-allow-metrics
-  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cloudnative-observability-operator.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "cloudnative-observability-operator.name" . }}
+      {{- include "cloudnative-observability-operator.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
   ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.networkPolicy.prometheusNamespace | quote }}
-      ports:
-        - port: {{ .Values.networkPolicy.metricsPort }}
-          protocol: TCP
----
-{{- if .Values.networkPolicy.otlp.inCluster.enabled }}
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: {{ include "cloudnative-observability-operator.fullname" . }}-allow-otlp-egress-incluster
-  namespace: {{ .Release.Namespace }}
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/name: {{ include "cloudnative-observability-operator.name" . }}
-  egress:
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.networkPolicy.otlp.inCluster.namespace | quote }}
-          podSelector:
-{{ toYaml .Values.networkPolicy.otlp.inCluster.podSelector | indent 12 }}
-      ports:
-        - port: {{ .Values.networkPolicy.otlp.inCluster.port }}
-          protocol: TCP
-  policyTypes: ["Egress"]
-{{- end }}
----
-{{- if .Values.networkPolicy.otlp.external.enabled }}
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: {{ include "cloudnative-observability-operator.fullname" . }}-allow-otlp-egress-external
-  namespace: {{ .Release.Namespace }}
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/name: {{ include "cloudnative-observability-operator.name" . }}
-  egress:
-    - to:
-      {{- range $cidr := .Values.networkPolicy.otlp.external.ipBlockCIDRs }}
-        - ipBlock:
-            cidr: {{ $cidr | quote }}
-      {{- end }}
-      ports:
-        - port: {{ .Values.networkPolicy.otlp.external.port }}
-          protocol: TCP
-  policyTypes: ["Egress"]
-{{- end }}
+    - ports:
+        - port: {{ $metricsPort }}
 {{- end }}

--- a/charts/cloudnative-observability-operator/templates/service.yaml
+++ b/charts/cloudnative-observability-operator/templates/service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cno.fullname" . }}
+  name: {{ include "cloudnative-observability-operator.fullname" . }}
   labels:
-    {{- include "cno.labels" . | nindent 4 }}
+    {{- include "cloudnative-observability-operator.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   selector:
-    {{- include "cno.selectorLabels" . | nindent 4 }}
+    {{- include "cloudnative-observability-operator.selectorLabels" . | nindent 4 }}
   ports:
     - name: metrics
       port: 8080

--- a/charts/cloudnative-observability-operator/templates/serviceaccount.yaml
+++ b/charts/cloudnative-observability-operator/templates/serviceaccount.yaml
@@ -1,12 +1,27 @@
-{{- if .Values.serviceAccount.create }}
+{{- /*
+ServiceAccount:
+  - .Values.serviceAccount.create が true のときだけ作成
+  - name/annotations/automountServiceAccountToken はオプション
+  - ヘルパーは _helpers.tpl の cloudnative-observability-operator.* を使用
+*/ -}}
+
+{{- $vals := .Values -}}
+{{- $sa := (and (hasKey $vals "serviceAccount") (kindIs "map[string]interface {}" $vals.serviceAccount)) | ternary $vals.serviceAccount (dict) -}}
+{{- $create := (hasKey $sa "create") | ternary $sa.create true -}}
+{{- $name := include "cloudnative-observability-operator.serviceAccountName" . -}}
+{{- $ann := (and (hasKey $sa "annotations") (kindIs "map[string]interface {}" $sa.annotations)) | ternary $sa.annotations (dict) -}}
+{{- $automount := (hasKey $sa "automountServiceAccountToken") | ternary $sa.automountServiceAccountToken true -}}
+
+{{- if $create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ default (include "cno.fullname" .) .Values.serviceAccount.name }}
+  name: {{ $name }}
   labels:
-    {{- include "cno.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+    {{- include "cloudnative-observability-operator.labels" . | nindent 4 }}
+  {{- with $ann }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ $automount }}
 {{- end }}

--- a/charts/cloudnative-observability-operator/templates/servicemonitor.yaml
+++ b/charts/cloudnative-observability-operator/templates/servicemonitor.yaml
@@ -1,30 +1,45 @@
-{{- if and .Values.serviceMonitor.enabled .Values.telemetry.metrics.enabled }}
+{{- /*
+Render ServiceMonitor only when:
+  1) telemetry.metrics.enabled == true（途中のキーが無い/型が違う場合は false 扱い）
+  2) The CRD monitoring.coreos.com/v1 exists
+*/ -}}
+
+{{- $vals := .Values -}}
+
+{{- /* telemetry が map のときだけ採用、違えば空 dict */ -}}
+{{- $tele := (and (hasKey $vals "telemetry") (kindIs "map[string]interface {}" $vals.telemetry)) | ternary $vals.telemetry (dict) -}}
+
+{{- /* metrics も同様にガード */ -}}
+{{- $metrics := (and (hasKey $tele "metrics") (kindIs "map[string]interface {}" $tele.metrics)) | ternary $tele.metrics (dict) -}}
+
+{{- /* enabled が存在すればその値、無ければ false */ -}}
+{{- $enabled := (hasKey $metrics "enabled") | ternary $metrics.enabled false -}}
+
+{{- /* デフォルト付きの取り出し */ -}}
+{{- $portName := (hasKey $metrics "portName") | ternary $metrics.portName "https" -}}
+{{- $scheme   := (hasKey $metrics "scheme")   | ternary $metrics.scheme   "https" -}}
+{{- $interval := (hasKey $metrics "interval") | ternary $metrics.interval "30s"  -}}
+{{- $extra    := (and (hasKey $metrics "extraLabels") (kindIs "map[string]interface {}" $metrics.extraLabels)) | ternary $metrics.extraLabels (dict) -}}
+
+{{- if and $enabled (has "monitoring.coreos.com/v1" .Capabilities.APIVersions) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "cno.fullname" . }}
+  name: {{ include "cloudnative-observability-operator.fullname" . }}
   labels:
-    {{- include "cno.labels" . | nindent 4 }}
-    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- include "cloudnative-observability-operator.labels" . | nindent 4 }}
+    {{- with $extra }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
-      {{- include "cno.selectorLabels" . | nindent 6 }}
+      {{- include "cloudnative-observability-operator.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   endpoints:
-    - port: {{ default "metrics" .Values.service.portName }}
-      path: {{ default "/metrics" .Values.serviceMonitor.path }}
-      interval: {{ .Values.serviceMonitor.interval }}
-      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
-      scheme: {{ default "http" .Values.serviceMonitor.scheme }}
-      honorLabels: {{ default true .Values.serviceMonitor.honorLabels }}
-      {{- with .Values.serviceMonitor.metricRelabelings }}
-      metricRelabelings:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.serviceMonitor.relabelings }}
-      relabelings:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+    - port: {{ $portName | quote }}
+      scheme: {{ $scheme | quote }}
+      interval: {{ $interval | quote }}
 {{- end }}

--- a/charts/cloudnative-observability-operator/values.yaml
+++ b/charts/cloudnative-observability-operator/values.yaml
@@ -93,3 +93,9 @@ telemetry:
     sampler: "parentbased_treceidratio"
     sampleArg: 0.1
     serviceName: "cloudnative-observability-operator"
+  metrics:
+    enabled: false        # ← デフォルトで無効（必要なとき true）
+    portName: https       # Service のメトリクス用ポート名に合わせる
+    scheme: https
+    interval: 30s
+    extraLabels: {}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,7 +63,7 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: controller:latest
+        image: controller:0.0.0
         name: manager
         ports: []
         securityContext:

--- a/hack/verify-chart-version.sh
+++ b/hack/verify-chart-version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHART_DIR="${1:-charts/cloudnative-observability-operator}"
+CHART_YAML="${CHART_DIR}/Chart.yaml"
+
+if [[ ! -f "$CHART_YAML" ]]; then
+  echo "::error ::Chart.yaml not found at ${CHART_YAML}"
+  exit 1
+fi
+
+# yq v4 をGo経由で導入（CIでは Go が入っている前提）
+if ! command -v yq >/dev/null 2>&1; then
+  echo "Installing yq..."
+  go install github.com/mikefarah/yq/v4@latest
+  export PATH="${PATH}:$(go env GOPATH)/bin"
+fi
+
+version="$(yq '.version' "${CHART_YAML}" | tr -d '"')"
+appVersion="$(yq '.appVersion' "${CHART_YAML}" | tr -d '"')"
+
+echo "Chart version=${version} / appVersion=${appVersion}"
+
+if [[ -z "${version}" || -z "${appVersion}" ]]; then
+  echo "::error ::version or appVersion is empty."
+  exit 1
+fi
+
+if [[ "${version}" != "${appVersion}" ]]; then
+  echo "::error ::Chart.yaml 'version' must equal 'appVersion' (contract)."
+  exit 1
+fi
+
+echo "OK: Chart version == appVersion"

--- a/hack/verify-no-latest.sh
+++ b/hack/verify-no-latest.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 監査対象:
+#   - Helm/manifest YAML: charts/**, config/**
+#   - Dockerfile / Dockerfile.*
+# 除外:
+#   - ドキュメント: **/*.md, **/README*
+#   - Makefile
+#   - 自分自身
+#   - バックアップ/テンプレ類: **/*.bak, **/*.tmpl
+
+# 対象ファイル一覧を取得（git管理下のみ）
+files="$(git ls-files \
+  'charts/**' \
+  'config/**' \
+  'Dockerfile' \
+  'Dockerfile.*' \
+  ':!:**/*.md' \
+  ':!:**/README*' \
+  ':!:Makefile' \
+  ':!:hack/verify-no-latest.sh' \
+  ':!:**/*.bak' \
+  ':!:**/*.tmpl' \
+  || true)"
+
+# 何もなければOK
+if [ -z "${files}" ]; then
+  echo "OK: no ':latest' usage found."
+  exit 0
+fi
+
+# 検出パターン:
+#   - ":latest"
+#   - "tag: latest"
+#   - "image: <repo>:latest"
+PATTERN='(:latest\b|tag:\s*latest\b|image:\s*[^\s]+:latest\b)'
+
+# grep はヒット無しで終了コード1を返すので || true で握る
+matches="$(echo "${files}" | xargs grep -n -E "${PATTERN}" || true)"
+
+if [ -n "${matches}" ]; then
+  echo "${matches}"
+  echo "::error ::Detected disallowed ':latest' tag usage. Pin image tags explicitly."
+  exit 2
+fi
+
+echo "OK: no ':latest' usage found."

--- a/internal/controller/grpcburner_controller.go
+++ b/internal/controller/grpcburner_controller.go
@@ -47,7 +47,7 @@ func (r *GrpcBurnerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	if !gb.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !gb.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(&gb, finalizerName) {
 			controllerutil.RemoveFinalizer(&gb, finalizerName)
 			if err := r.Update(ctx, &gb); err != nil {
@@ -155,15 +155,15 @@ func (r *GrpcBurnerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(wrapped)
 }
 
-func mergeMap(dst, src map[string]string) map[string]string {
-	if dst == nil && src == nil {
-		return nil
-	}
-	if dst == nil {
-		dst = map[string]string{}
-	}
-	for k, v := range src {
-		dst[k] = v
-	}
-	return dst
-}
+// func mergeMap(dst, src map[string]string) map[string]string {
+// 	if dst == nil && src == nil {
+// 		return nil
+// 	}
+// 	if dst == nil {
+// 		dst = map[string]string{}
+// 	}
+// 	for k, v := range src {
+// 		dst[k] = v
+// 	}
+// 	return dst
+// }

--- a/internal/controller/observabilityconfig_controller_test.go
+++ b/internal/controller/observabilityconfig_controller_test.go
@@ -109,7 +109,7 @@ var _ = Describe("ObservabilityConfig Controller", func() {
 					Equal("Reconciled"),
 					Equal(conditions.ReasonDeploymentAvailable),
 				))
-			}, 3*time.Second, 200*time.Millisecond).Should(Succeed())
+			}, 5*time.Second, 200*time.Millisecond).Should(Succeed())
 		})
 	})
 })

--- a/internal/shared/telemetry/tracing.go
+++ b/internal/shared/telemetry/tracing.go
@@ -65,7 +65,7 @@ func InitTracer(ctx context.Context) (func(context.Context) error, error) {
 	sampler := envStr("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
 	arg := envFloat("OTEL_TRACES_SAMPLER_ARG", 0.1)
 
-	var s sdktrace.Sampler = sdktrace.ParentBased(sdktrace.TraceIDRatioBased(arg))
+	s := sdktrace.ParentBased(sdktrace.TraceIDRatioBased(arg))
 	switch sampler {
 	case "always_on":
 		s = sdktrace.AlwaysSample()


### PR DESCRIPTION
## 概要

PR の基準未達（lint/test/Helm/契約/ビルド可能性）がある場合に **ブロック**する仕組みを導入しました。  
ローカルおよび CI で `make ci-all` を実行することで、以下を直列チェックします。

- golangci-lint
- コード生成（controller-gen）/ fmt / vet
- unit/envtest（/e2e 除外）
- Helm lint（テンプレの nil-safe 化込み）
- 契約チェック
  - `:latest` 使用禁止（charts/**, config/**, Dockerfile* に限定）
  - Chart `version == appVersion`
- docker buildx（linux/amd64, `--load`, **no push**）でビルド可能性確認

## 変更内容（What / Why）

### Makefile
- `ci-all` を追加し上記フローを統合。
- `docker-buildx-ci`（`<IMG_REPO>:ci-test` を `--load`）と `helm-contracts` を追加。
- `docker-build`, `docker-buildx-amd64` で `VERSION=latest` を拒否。